### PR TITLE
CentOS 8 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ A simple, but fairly parameterized, role for setting up a FreeIPA server. Primar
 Requirements
 ------------
 
-Primarily tested and functional on Fedora, but open to others.
+- Primarily tested and functional on Fedora, but open to others.
+- CentOS 8
+- CentOS 7
 
 Role Variables
 --------------

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ A simple, but fairly parameterized, role for setting up a FreeIPA server. Primar
 Requirements
 ------------
 
-- Primarily tested and functional on Fedora, but open to others.
 - CentOS 8
 - CentOS 7
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,8 +1,3 @@
 ---
 - name: reload firewalld
   command: firewall-cmd --reload
-
-- name: restart NetworkManager
-  service:
-    name: NetworkManager
-    state: restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,8 @@
 ---
 - name: reload firewalld
   command: firewall-cmd --reload
+
+- name: restart NetworkManager
+  service:
+    name: NetworkManager
+    state: restarted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,6 +8,7 @@ galaxy_info:
   - name: EL
     versions:
     - 7
+    - 8
   - name: Fedora
     versions:
     - all

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
   
 - name: Ensure software is installed (dnf)
   package: 
-    name: "{{ ipaserver_packages }}
+    name: "{{ ipaserver_packages }}"
     state: present
   when: (ansible_distribution == "CentOS" and ansible_distribution_version|int = 8)
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,11 @@
   package: 
     name: "{{ ipaserver_packages }}" 
     state: present
+ 
+- name: Add Allow Recursive Rule
+  lineinfile:
+    path: /etc/named/ipa-options-ext.conf
+    line: allow-recursion { any; };
 
 - name: Run the installer
   command: "{{ ipaserver_base_command }} {{ ipaserver_base_command_arguments }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,23 +29,5 @@
   args:
     creates: /etc/ipa/default.conf
     
-- name: Add Allow Recursive Rule
-  lineinfile:
-    path: /etc/named/ipa-options-ext.conf
-    line: allow-recursion { any; };
-  when: 
-    - ansible_distribution == "CentOS"
-    - ansible_distribution_major_version == "8"
-    
-- name: Add DNS server entry in zzz-ipa.conf file
-  lineinfile:
-    dest: /etc/NetworkManager/conf.d/zzz-ipa.conf
-    regexp: '^servers'
-    line: "servers={{ hostvars[(groups['freeipa'] | sort)[0]]['ansible_host'] }},{{ hostvars[(groups['freeipa'] | sort)[1]]['ansible_host'] }}"
-  notify: restart NetworkManager
-  when: 
-    - ansible_distribution == "CentOS"
-    - ansible_distribution_major_version == "8"
-
 - include: firewalld.yml
   when: ipaserver_manage_firewalld

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,12 +18,6 @@
   when: 
     - ansible_distribution == "CentOS"
     - ansible_distribution_major_version == "8"
-
-- name: Sync the Repo
-  command: "dnf distro-sync"
-  when: 
-    - ansible_distribution == "CentOS"
-    - ansible_distribution_major_version == "8"
     
 - name: Ensure software is installed (yum)
   package: 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,7 +39,7 @@
     
 - name: Add DNS server entry in zzz-ipa.conf file
   lineinfile:
-    dest: /etc/hosts
+    dest: /etc/NetworkManager/conf.d/zzz-ipa.conf
     regexp: '^servers'
     line: "servers={{ hostvars[(groups['freeipa'] | sort)[0]]['ansible_host'] }},{{ hostvars[(groups['freeipa'] | sort)[1]]['ansible_host'] }}"
   notify: restart NetworkManager

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,6 +33,9 @@
   lineinfile:
     path: /etc/named/ipa-options-ext.conf
     line: allow-recursion { any; };
+  when: 
+    - ansible_distribution == "CentOS"
+    - ansible_distribution_major_version == "8"
     
 - name: Add DNS server entry in zzz-ipa.conf file
   lineinfile:
@@ -40,6 +43,9 @@
     regexp: '^servers'
     line: "servers={{ hostvars[(groups['freeipa'] | sort)[0]]['ansible_host'] }},{{ hostvars[(groups['freeipa'] | sort)[1]]['ansible_host'] }}"
   notify: restart NetworkManager
+  when: 
+    - ansible_distribution == "CentOS"
+    - ansible_distribution_major_version == "8"
 
 - include: firewalld.yml
   when: ipaserver_manage_firewalld

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,18 +10,25 @@
     owner: root
     group: root
     mode: 0644
+    
+- name: Enable FreeIPA Repo
+  dnf:
+    name: '@idm:DL1'
+    state: present
+  when: 
+    - ansible_distribution == "CentOS"
+    - ansible_distribution_major_version == "8"
 
+- name: Sync the Repo
+  command: "dnf distro-sync"
+  when: 
+    - ansible_distribution == "CentOS"
+    - ansible_distribution_major_version == "8"
+    
 - name: Ensure software is installed (yum)
   package: 
     name: "{{ ipaserver_packages }}" 
     state: present
-  when: (ansible_distribution == "CentOS" and ansible_distribution_version|int = 7)
-  
-- name: Ensure software is installed (dnf)
-  package: 
-    name: "{{ ipaserver_packages }}"
-    state: present
-  when: (ansible_distribution == "CentOS" and ansible_distribution_version|int = 8)
 
 - name: Run the installer
   command: "{{ ipaserver_base_command }} {{ ipaserver_base_command_arguments }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,12 @@
   package: 
     name: "{{ ipaserver_packages }}" 
     state: present
+  when: ansible_distribution == "CentOS" and ansible_distribution_version|int = 7)
+  
+- name: Ensure software is installed (dnf)
+  package: 
+    name="{{ ipaserver_packages }}
+  when: ansible_distribution == "CentOS" and ansible_distribution_version|int = 8)
 
 - name: Run the installer
   command: "{{ ipaserver_base_command }} {{ ipaserver_base_command_arguments }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,15 +24,22 @@
     name: "{{ ipaserver_packages }}" 
     state: present
  
-- name: Add Allow Recursive Rule
-  lineinfile:
-    path: /etc/named/ipa-options-ext.conf
-    line: allow-recursion { any; };
-
 - name: Run the installer
   command: "{{ ipaserver_base_command }} {{ ipaserver_base_command_arguments }}"
   args:
     creates: /etc/ipa/default.conf
+    
+- name: Add Allow Recursive Rule
+  lineinfile:
+    path: /etc/named/ipa-options-ext.conf
+    line: allow-recursion { any; };
+    
+- name: Add DNS server entry in zzz-ipa.conf file
+  lineinfile:
+    dest: /etc/hosts
+    regexp: '^servers'
+    line: "servers={{ hostvars[(groups['freeipa'] | sort)[0]]['ansible_host'] }},{{ hostvars[(groups['freeipa'] | sort)[1]]['ansible_host'] }}"
+  notify: restart NetworkManager
 
 - include: firewalld.yml
   when: ipaserver_manage_firewalld

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,12 +15,13 @@
   package: 
     name: "{{ ipaserver_packages }}" 
     state: present
-  when: ansible_distribution == "CentOS" and ansible_distribution_version|int = 7)
+  when: (ansible_distribution == "CentOS" and ansible_distribution_version|int = 7)
   
 - name: Ensure software is installed (dnf)
   package: 
-    name="{{ ipaserver_packages }}
-  when: ansible_distribution == "CentOS" and ansible_distribution_version|int = 8)
+    name: "{{ ipaserver_packages }}
+    state: present
+  when: (ansible_distribution == "CentOS" and ansible_distribution_version|int = 8)
 
 - name: Run the installer
   command: "{{ ipaserver_base_command }} {{ ipaserver_base_command_arguments }}"


### PR DESCRIPTION
Installing ipa-server on CentOS 8 requires that that the associated repo be enabled.